### PR TITLE
fix payload pointer when PDU content is shifted

### DIFF
--- a/cantcoap.cpp
+++ b/cantcoap.cpp
@@ -1317,6 +1317,10 @@ void CoapPDU::shiftPDUUp(int shiftOffset, int shiftAmount) {
 		destPointer--;
 		srcPointer--;
 	}
+	// shift the payload pointer
+	if (_payloadLength > 0) {
+		_payloadPointer += shiftOffset;
+	}
 }
 
 /// Moves a block of bytes down a specified number of steps.
@@ -1334,6 +1338,10 @@ void CoapPDU::shiftPDUDown(int startLocation, int shiftOffset, int shiftAmount) 
 		_pdu[startLocation] = _pdu[srcPointer];
 		startLocation++;
 		srcPointer++;
+	}
+	// shift the payload pointer
+	if (_payloadLength > 0) {
+		_payloadPointer -= shiftOffset;
 	}
 }
 


### PR DESCRIPTION
Adding the token after the payload would cause the `_payloadPointer` to be off by a few bytes.
The actual content was not be corrupted, but e.g. the output of `printHuman()` was.